### PR TITLE
Add soul to package roulette

### DIFF
--- a/app-main/components/RouletteAnimation.module.css
+++ b/app-main/components/RouletteAnimation.module.css
@@ -1,0 +1,81 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.container {
+  position: relative;
+  width: 90%;
+  max-width: 600px;
+  overflow: hidden;
+  /* fade edges */
+  isolation: isolate;
+}
+
+.container::before,
+.container::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 60px;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.container::before {
+  left: 0;
+  background: linear-gradient(to right, rgba(0, 0, 0, 0.8), transparent);
+}
+
+.container::after {
+  right: 0;
+  background: linear-gradient(to left, rgba(0, 0, 0, 0.8), transparent);
+}
+
+.track {
+  display: flex;
+  width: fit-content;
+  animation: scroll linear infinite;
+}
+
+.image {
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+  margin: 0 4px;
+  border-radius: 6px;
+}
+
+.highlight {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 84px;
+  margin-left: -42px;
+  border-left: 2px solid #fff;
+  border-right: 2px solid #fff;
+  pointer-events: none;
+}
+
+.text {
+  margin-top: 16px;
+  color: #fff;
+  font-size: 1.25rem;
+  text-align: center;
+}
+
+@keyframes scroll {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}

--- a/app-main/components/RouletteAnimation.tsx
+++ b/app-main/components/RouletteAnimation.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect } from 'react';
+import styles from './RouletteAnimation.module.css';
+
+interface RouletteAnimationProps {
+  images: string[];
+  duration?: number;
+  onComplete?: () => void;
+}
+
+const RouletteAnimation: React.FC<RouletteAnimationProps> = ({ images, duration = 4000, onComplete }) => {
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      onComplete?.();
+    }, duration);
+    return () => clearTimeout(timer);
+  }, [duration, onComplete]);
+
+  const repeated = [...images, ...images, ...images];
+
+  return (
+    <div className={styles.overlay}>
+      <div className={styles.container}>
+        <div className={styles.track} style={{ animationDuration: `${duration}ms` }}>
+          {repeated.map((src, idx) => (
+            <img key={idx} src={src} alt="drink" className={styles.image} />
+          ))}
+        </div>
+        <div className={styles.highlight}></div>
+      </div>
+      <div className={styles.text}>Åbner pakke...</div>
+    </div>
+  );
+};
+
+export default RouletteAnimation;

--- a/app-main/pages/products/vi-blander-for-dig/[slug].tsx
+++ b/app-main/pages/products/vi-blander-for-dig/[slug].tsx
@@ -10,6 +10,8 @@ import Loading from '../../../components/Loading';
 import LoadingButton from '../../../components/LoadingButton';
 import LoadingConfettiButton from '../../../components/LoadingConfettiButton';
 import ConfettiAnimation from '../../../components/ConfettiAnimation';
+import RouletteAnimation from '../../../components/RouletteAnimation';
+import FireworkAnimation from '../../../components/FireworkAnimation';
 import { getCookie } from '../../../lib/cookies';
 
 /** Data from DB about package sizes. */
@@ -75,6 +77,8 @@ export default function ViBlanderForDigProduct() {
   const [isGenerating, setIsGenerating] = useState<boolean>(false);
   const [isAddingToCart, setIsAddingToCart] = useState<boolean>(false);
   const [showConfetti, setShowConfetti] = useState<boolean>(false);
+  const [showRoulette, setShowRoulette] = useState<boolean>(false);
+  const [showFireworks, setShowFireworks] = useState<boolean>(false);
 
   // The session_id read from cookie
   const [sessionId, setSessionId] = useState<string | null>(null);
@@ -257,6 +261,8 @@ export default function ViBlanderForDigProduct() {
       alert('Error creating selection');
     } finally {
       setIsGenerating(false);
+      setShowRoulette(false);
+      setShowFireworks(true);
     }
   }
 
@@ -290,6 +296,8 @@ export default function ViBlanderForDigProduct() {
    * Overwrite selection => call createTemporarySelection again
    */
   async function regenerateSelection() {
+    setShowFireworks(false);
+    setShowRoulette(true);
     await createTemporarySelection(true);
   }
 
@@ -480,6 +488,15 @@ export default function ViBlanderForDigProduct() {
           onAnimationEnd={handleConfettiEnd}
           buttonRef={addToCartButtonRef}
         />
+      )}
+      {showRoulette && (
+        <RouletteAnimation
+          images={Object.values(drinksData).map((d) => `${SUPABASE_URL}${d.image}`)}
+          onComplete={() => setShowRoulette(false)}
+        />
+      )}
+      {showFireworks && (
+        <FireworkAnimation onAnimationEnd={() => setShowFireworks(false)} />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- enhance roulette overlay with fading edges and text
- trigger fireworks after package generation completes
- show roulette overlay with custom message while loading

## Testing
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844833ecb04832cb01127a78b61e983